### PR TITLE
LAC-955: add Excel download for tally sheet

### DIFF
--- a/app/Exports/LoadedContainerTallySheetExcelExport.php
+++ b/app/Exports/LoadedContainerTallySheetExcelExport.php
@@ -49,8 +49,8 @@ class LoadedContainerTallySheetExcelExport implements FromArray, ShouldAutoSize,
             '',
             '',
             '',
-            'SHIPMENT NO:'.($this->container->reference ?? ''),
             '',
+            'SHIPMENT NO:'.($this->container->reference ?? ''),
             '',
         ];
 
@@ -188,8 +188,8 @@ class LoadedContainerTallySheetExcelExport implements FromArray, ShouldAutoSize,
 
                 // Merge container info cells
                 $sheet->mergeCells('A3:B3'); // CONTR NO
-                $sheet->mergeCells('D3:I3'); // DATE LOADED
-                $sheet->mergeCells('J3:L3'); // SHIPMENT NO
+                $sheet->mergeCells('D3:J3'); // DATE LOADED
+                $sheet->mergeCells('K3:L3'); // SHIPMENT NO
 
                 // Merge TYPE OF PACKAGE columns in header row
                 $sheet->mergeCells('F4:J4'); // TYPE OF PACKAGE
@@ -259,7 +259,7 @@ class LoadedContainerTallySheetExcelExport implements FromArray, ShouldAutoSize,
                 ]);
 
                 // Apply bottom border only to specific cells (C, D, E for GRAND TOTAL, CBM, TOT)
-                $sheet->getStyle('C'.$grandTotalRow.':E'.$grandTotalRow)->applyFromArray([
+                $sheet->getStyle('D'.$grandTotalRow.':E'.$grandTotalRow)->applyFromArray([
                     'borders' => [
                         'bottom' => [
                             'borderStyle' => Border::BORDER_THIN,

--- a/app/Exports/LoadedContainerTallySheetExcelExport.php
+++ b/app/Exports/LoadedContainerTallySheetExcelExport.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace App\Exports;
+
+use App\Actions\HBL\GetHBLByHBLNumber;
+use App\Models\Container;
+use Carbon\Carbon;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\ShouldAutoSize;
+use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Concerns\WithStyles;
+use Maatwebsite\Excel\Events\AfterSheet;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
+use PhpOffice\PhpSpreadsheet\Style\Border;
+use PhpOffice\PhpSpreadsheet\Style\Fill;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+class LoadedContainerTallySheetExcelExport implements FromArray, ShouldAutoSize, WithEvents, WithStyles
+{
+    use Exportable;
+
+    private Container $container;
+
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    public function array(): array
+    {
+        $data = $this->prepareData();
+        $rows = [];
+
+        // Header row - LOADING TALLY SHEET
+        $rows[] = ['LOADING TALLY SHEET', '', '', '', '', '', '', ''];
+
+        // Container info row
+        $rows[] = [
+            'CONTR NO: '.($this->container->container_number ?? ''),
+            '',
+            'DATE LOADED: '.Carbon::parse($this->container->loading_started_at ?? now())->format('Y-m-d'),
+            '',
+            '',
+            '',
+            'SHIPMENT NO: '.($this->container->reference ?? ''),
+            '',
+        ];
+
+        // Column headers
+        $rows[] = [
+            'SN',
+            'HBL',
+            'NAME OF CUSTOMER',
+            'CBM',
+            'TOT',
+            'TYPE OF PACKAGE',
+            'DESTINATION',
+            'REMARKS',
+        ];
+
+        // Data rows
+        $serialNumber = 1;
+        foreach ($data as $item) {
+            $packageTypes = is_array($item[4]) ? implode(', ', array_filter($item[4])) : '';
+
+            $rows[] = [
+                $serialNumber++,
+                $item[0], // HBL
+                strtoupper($item[1]), // Customer Name
+                number_format($item[2], 3), // CBM with 3 decimal places
+                $item[3], // TOT
+                $packageTypes, // Package Types combined
+                $item[5], // Destination
+                $item[6] ?? '', // Remarks
+            ];
+        }
+
+        return $rows;
+    }
+
+    private function prepareData(): array
+    {
+        $data = [];
+
+        // Get the currently loaded HBL package IDs
+        $currentlyLoadedPackageIds = $this->container->hbl_packages->pluck('id')->toArray();
+
+        // Filter duplicate_hbl_packages to only include those that are still in the container's hbl_packages
+        $filteredPackages = $this->container->load('duplicate_hbl_packages.hbl.mhbl')->duplicate_hbl_packages->filter(function ($package) use ($currentlyLoadedPackageIds) {
+            return in_array($package->id, $currentlyLoadedPackageIds);
+        });
+
+        $groupedPackages = $filteredPackages->groupBy(function ($package) {
+            return $package->hbl->hbl_number;
+        });
+
+        foreach ($groupedPackages as $hblNumber => $hblPackages) {
+            $hbl = GetHBLByHBLNumber::run($hblNumber);
+            $data[] = [
+                $hbl->hbl_number,
+                $hbl->hbl_name,
+                $hblPackages->sum('volume'),
+                count($hblPackages),
+                $hblPackages->pluck('package_type')->values()->all(),
+                $hbl->warehouse === 'COLOMBO' ? 'CMB' : 'NTR',
+                '',
+            ];
+        }
+
+        return $data;
+    }
+
+    public function styles(Worksheet $sheet)
+    {
+        return [
+            // Header row styling
+            1 => [
+                'font' => ['bold' => true, 'size' => 12],
+                'alignment' => ['horizontal' => Alignment::HORIZONTAL_CENTER, 'vertical' => Alignment::VERTICAL_CENTER],
+                'fill' => ['fillType' => Fill::FILL_SOLID, 'color' => ['rgb' => 'E8E8E8']],
+            ],
+            // Info row styling
+            2 => [
+                'font' => ['bold' => true, 'size' => 9],
+                'alignment' => ['vertical' => Alignment::VERTICAL_CENTER],
+                'fill' => ['fillType' => Fill::FILL_SOLID, 'color' => ['rgb' => 'F5F5F5']],
+            ],
+            // Column headers styling
+            3 => [
+                'font' => ['bold' => true, 'size' => 10],
+                'alignment' => ['horizontal' => Alignment::HORIZONTAL_CENTER, 'vertical' => Alignment::VERTICAL_CENTER],
+                'fill' => ['fillType' => Fill::FILL_SOLID, 'color' => ['rgb' => 'E8E8E8']],
+            ],
+        ];
+    }
+
+    public function registerEvents(): array
+    {
+        return [
+            AfterSheet::class => function (AfterSheet $event) {
+                $sheet = $event->sheet->getDelegate();
+
+                // Merge header cell
+                $sheet->mergeCells('A1:H1');
+
+                // Merge container info cells
+                $sheet->mergeCells('A2:B2'); // CONTR NO
+                $sheet->mergeCells('C2:F2'); // DATE LOADED
+                $sheet->mergeCells('G2:H2'); // SHIPMENT NO
+
+                // Set borders for all cells
+                $highestRow = $sheet->getHighestRow();
+                $sheet->getStyle('A1:H'.$highestRow)->applyFromArray([
+                    'borders' => [
+                        'allBorders' => [
+                            'borderStyle' => Border::BORDER_THIN,
+                            'color' => ['rgb' => '000000'],
+                        ],
+                    ],
+                ]);
+
+                // Set row heights
+                $sheet->getRowDimension(1)->setRowHeight(25);
+                $sheet->getRowDimension(2)->setRowHeight(20);
+                $sheet->getRowDimension(3)->setRowHeight(20);
+
+                // Set column widths
+                $sheet->getColumnDimension('A')->setWidth(6);   // SN
+                $sheet->getColumnDimension('B')->setWidth(12);  // HBL
+                $sheet->getColumnDimension('C')->setWidth(20);  // NAME OF CUSTOMER
+                $sheet->getColumnDimension('D')->setWidth(8);   // CBM
+                $sheet->getColumnDimension('E')->setWidth(6);   // TOT
+                $sheet->getColumnDimension('F')->setWidth(15);  // TYPE OF PACKAGE
+                $sheet->getColumnDimension('G')->setWidth(12);  // DESTINATION
+                $sheet->getColumnDimension('H')->setWidth(12);  // REMARKS
+
+                // Apply center alignment to data rows
+                $sheet->getStyle('A4:H'.$highestRow)->applyFromArray([
+                    'alignment' => [
+                        'horizontal' => Alignment::HORIZONTAL_CENTER,
+                        'vertical' => Alignment::VERTICAL_CENTER,
+                    ],
+                ]);
+
+                // Left align customer names (column C)
+                $sheet->getStyle('C4:C'.$highestRow)->applyFromArray([
+                    'alignment' => [
+                        'horizontal' => Alignment::HORIZONTAL_LEFT,
+                        'vertical' => Alignment::VERTICAL_CENTER,
+                    ],
+                ]);
+
+                // Apply word wrap for TYPE OF PACKAGE column
+                $sheet->getStyle('F4:F'.$highestRow)->applyFromArray([
+                    'alignment' => [
+                        'wrapText' => true,
+                        'horizontal' => Alignment::HORIZONTAL_CENTER,
+                        'vertical' => Alignment::VERTICAL_CENTER,
+                    ],
+                ]);
+            },
+        ];
+    }
+}

--- a/app/Http/Controllers/LoadedContainerController.php
+++ b/app/Http/Controllers/LoadedContainerController.php
@@ -118,4 +118,11 @@ class LoadedContainerController extends Controller
 
         return $this->loadedContainerRepository->tallySheetDownloadPDF($container);
     }
+
+    public function tallySheetDownloadExcel($container)
+    {
+        $this->authorize('shipment.download tally sheet');
+
+        return $this->loadedContainerRepository->tallySheetDownloadExcel($container);
+    }
 }

--- a/app/Interfaces/LoadedContainerRepositoryInterface.php
+++ b/app/Interfaces/LoadedContainerRepositoryInterface.php
@@ -21,4 +21,6 @@ interface LoadedContainerRepositoryInterface
     public function loadMHBL(array $data);
 
     public function tallySheetDownloadPDF($container);
+
+    public function tallySheetDownloadExcel($container);
 }

--- a/app/Repositories/LoadedContainerRepository.php
+++ b/app/Repositories/LoadedContainerRepository.php
@@ -14,6 +14,7 @@ use App\Enum\ContainerStatus;
 use App\Enum\HBLType;
 use App\Exports\DoorToDoorManifestExport;
 use App\Exports\LoadedContainerManifestExport;
+use App\Exports\LoadedContainerTallySheetExcelExport;
 use App\Exports\LoadedContainerTallySheetExport;
 use App\Factory\Container\FilterFactory;
 use App\Http\Resources\ContainerResource;
@@ -27,6 +28,7 @@ use App\Traits\HandlesDeadlocks;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Log;
+use Maatwebsite\Excel\Facades\Excel;
 
 class LoadedContainerRepository implements GridJsInterface, LoadedContainerRepositoryInterface
 {
@@ -266,5 +268,15 @@ class LoadedContainerRepository implements GridJsInterface, LoadedContainerRepos
         $pdf->setPaper('a4', 'landscape');
 
         return $pdf->download($filename);
+    }
+
+    public function tallySheetDownloadExcel($container)
+    {
+        $container = Container::withoutGlobalScope(BranchScope::class)->findOrFail($container);
+        $filename = $container->reference.'_tally_sheet_'.date('Y_m_d_h_i_s').'.xlsx';
+
+        $export = new LoadedContainerTallySheetExcelExport($container);
+
+        return Excel::download($export, $filename);
     }
 }

--- a/resources/js/Pages/Loading/Partials/ReviewModal.vue
+++ b/resources/js/Pages/Loading/Partials/ReviewModal.vue
@@ -75,6 +75,10 @@ const handleDownLoadTallySheet = () => {
     window.location.href = route("loading.containers.tally-sheet-downloads", form.container_id);
 }
 
+const handleDownLoadTallySheetExcel = () => {
+    window.location.href = route("loading.containers.tally-sheet-excel-downloads", form.container_id);
+}
+
 const getMHBLPackageCount = (hbls) => {
     return hbls.reduce((total, hbl) => {
         return total + (hbl.packages ? hbl.packages.length : 0);
@@ -183,6 +187,13 @@ const handleCreateLoadedContainer = (printTallySheet) => {
                     size="small"
                     type="button"
                     @click.prevent="handleDownLoadTallySheet"></Button>
+
+            <Button icon="pi pi-file-excel" label="Download Tally Sheet (Excel)"
+                    outlined
+                    severity="success"
+                    size="small"
+                    type="button"
+                    @click.prevent="handleDownLoadTallySheetExcel"></Button>
 
             <Button label="Finish Loading & Download Tally Sheet" outlined
                     severity="help"

--- a/routes/web/loading.php
+++ b/routes/web/loading.php
@@ -93,6 +93,9 @@ Route::name('loading.')->group(function () {
     Route::get('containers/tally-sheet-downloads/{container}', [LoadedContainerController::class, 'tallySheetDownloadPDF'])
         ->name('containers.tally-sheet-downloads');
 
+    Route::get('containers/tally-sheet-excel-downloads/{container}', [LoadedContainerController::class, 'tallySheetDownloadExcel'])
+        ->name('containers.tally-sheet-excel-downloads');
+
     Route::post('containers/{container}/set/rtf', [ContainerController::class, 'setRTF'])
         ->name('containers.set.rtf');
 


### PR DESCRIPTION
- Add tallySheetDownloadExcel method to LoadedContainerController
- Extend LoadedContainerRepositoryInterface with tallySheetDownloadExcel
- Implement Excel export functionality in LoadedContainerRepository
- Add new route for tally sheet Excel download
- Introduce Excel download button in ReviewModal component
- Use Maatwebsite Excel package for exporting Excel files