### PR TITLE
LAC-960: always show Print All HBL link regardless of container status

### DIFF
--- a/resources/js/Pages/Common/Dialog/Container/Tabs/TabHBLUnderShipment.vue
+++ b/resources/js/Pages/Common/Dialog/Container/Tabs/TabHBLUnderShipment.vue
@@ -162,7 +162,7 @@ watch(
                         label="Add HBL To Shipment" size="small" @click.prevent="confirmAddHBLModal"/>
             </template>
 
-            <a v-if="container.status === 'LOADED'" :href="route('loading.hbls.batch-downloads', container.id)">
+            <a :href="route('loading.hbls.batch-downloads', container.id)">
                 <Button icon="pi pi-print" label="Print All HBL" severity="info" size="small"/>
             </a>
         </div>


### PR DESCRIPTION
- Removed condition that hid Print All HBL link when container status was not 'LOADED'
- Ensured link to batch download route is always accessible
- Simplified template logic for better user access to printing functionality