### PR TITLE
LAC-959: add selective package return feature with enhanced UI

### DIFF
--- a/app/Http/Controllers/CallCenter/QueueController.php
+++ b/app/Http/Controllers/CallCenter/QueueController.php
@@ -58,6 +58,11 @@ class QueueController extends Controller
         return $this->queueRepository->getPackageDetailsByToken($token);
     }
 
+    public function getPackagesForReturn($token): \Illuminate\Http\JsonResponse
+    {
+        return $this->queueRepository->getPackagesForReturn($token);
+    }
+
     public function returnPackage(ReturnPackageRequest $request)
     {
         $this->queueRepository->returnPackage($request->validated());

--- a/app/Http/Requests/ReturnPackageRequest.php
+++ b/app/Http/Requests/ReturnPackageRequest.php
@@ -22,8 +22,27 @@ class ReturnPackageRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'token_number' => 'required|string|exists:package_queues,token_id',
+            'token_number' => 'nullable|string', // Made optional for selective returns
             'remarks' => 'nullable|string',
+            'selected_packages' => 'sometimes|array|min:1',
+            'selected_packages.*.package_queue_id' => 'required_with:selected_packages|integer|exists:package_queues,id',
         ];
+    }
+
+    /**
+     * Custom validation to ensure either token_number or selected_packages is provided
+     */
+    public function withValidator($validator)
+    {
+        $validator->after(function ($validator) {
+            if (! $this->token_number && (! $this->selected_packages || empty($this->selected_packages))) {
+                $validator->errors()->add('token_number', 'Either token number or selected packages must be provided.');
+            }
+
+            // If selected_packages is provided, ensure at least one package is selected
+            if ($this->selected_packages && count($this->selected_packages) === 0) {
+                $validator->errors()->add('selected_packages', 'At least one package must be selected for return.');
+            }
+        });
     }
 }

--- a/app/Http/Requests/ReturnPackageRequest.php
+++ b/app/Http/Requests/ReturnPackageRequest.php
@@ -36,7 +36,7 @@ class ReturnPackageRequest extends FormRequest
     {
         $validator->after(function ($validator) {
             if (! $this->token_number && (! $this->selected_packages || empty($this->selected_packages))) {
-                $validator->errors()->add('token_number', 'Either token number or selected packages must be provided.');
+                $validator->errors()->add('form', 'Either token number or selected packages must be provided.');
             }
 
             // If selected_packages is provided, ensure at least one package is selected

--- a/app/Interfaces/CallCenter/QueueRepositoryInterface.php
+++ b/app/Interfaces/CallCenter/QueueRepositoryInterface.php
@@ -28,6 +28,8 @@ interface QueueRepositoryInterface
 
     public function getPackageDetailsByToken(string $token): JsonResponse;
 
+    public function getPackagesForReturn(string $token): JsonResponse;
+
     public function returnPackage(array $data): void;
 
     public function getPackageLogs(int $packageQueueId): JsonResponse;

--- a/app/Repositories/CallCenter/QueueRepository.php
+++ b/app/Repositories/CallCenter/QueueRepository.php
@@ -105,9 +105,128 @@ class QueueRepository implements QueueRepositoryInterface
         ]);
     }
 
+    public function getPackagesForReturn(string $token): JsonResponse
+    {
+        // Get all package queues for this token (including historical ones)
+        $packageQueues = PackageQueue::whereHas('token', function ($query) use ($token) {
+            $query->where('token', $token);
+        })
+            ->with([
+                'token.customer',
+                'token.hbl',
+                'releasedBy',
+                'releaseLogs' => function ($query) {
+                    $query->with('createdBy')->orderBy('created_at', 'desc');
+                },
+            ])
+            ->orderBy('created_at', 'desc')
+            ->get();
+
+        if ($packageQueues->isEmpty()) {
+            return response()->json(['error' => 'No packages found for this token'], 404);
+        }
+
+        $response = [];
+        foreach ($packageQueues as $packageQueue) {
+            $hbl = $packageQueue->token->hbl;
+            $hblReference = $hbl ? $hbl->reference : $packageQueue->reference;
+
+            // Group packages by HBL reference
+            if (! isset($response[$hblReference])) {
+                $response[$hblReference] = [
+                    'hbl_reference' => $hblReference,
+                    'customer' => $packageQueue->token->customer->name,
+                    'packages' => [],
+                    'total_packages' => 0,
+                    'released_packages' => 0,
+                ];
+            }
+
+            $packageData = [
+                'id' => $packageQueue->id,
+                'package_queue_id' => $packageQueue->id,
+                'reference' => $packageQueue->reference,
+                'package_count' => $packageQueue->package_count,
+                'is_released' => $packageQueue->is_released,
+                'released_at' => $packageQueue->released_at,
+                'released_packages' => $packageQueue->released_packages,
+                'released_by' => $packageQueue->releasedBy ? $packageQueue->releasedBy->name : null,
+                'note' => $packageQueue->note,
+                'created_at' => $packageQueue->created_at,
+                'logs' => $packageQueue->releaseLogs->map(function ($log) {
+                    return [
+                        'id' => $log->id,
+                        'type' => $log->type,
+                        'packages' => $log->packages,
+                        'remarks' => $log->remarks,
+                        'created_at' => $log->created_at,
+                        'created_by' => $log->createdBy ? $log->createdBy->name : null,
+                    ];
+                }),
+            ];
+
+            $response[$hblReference]['packages'][] = $packageData;
+            $response[$hblReference]['total_packages'] += $packageQueue->package_count;
+            if ($packageQueue->is_released) {
+                $response[$hblReference]['released_packages'] += $packageQueue->package_count;
+            }
+        }
+
+        return response()->json([
+            'token_number' => $token,
+            'customer' => $packageQueues->first()->token->customer->name,
+            'hbl_groups' => array_values($response),
+            'summary' => [
+                'total_hbls' => count($response),
+                'total_packages' => collect($response)->sum('total_packages'),
+                'released_packages' => collect($response)->sum('released_packages'),
+                'available_for_return' => collect($response)->sum('released_packages'),
+            ],
+        ]);
+    }
+
     public function returnPackage(array $data): void
     {
-        // Find the package queue by token number
+        // Handle selective package returns
+        if (isset($data['selected_packages']) && ! empty($data['selected_packages'])) {
+            foreach ($data['selected_packages'] as $packageData) {
+                $packageQueue = PackageQueue::find($packageData['package_queue_id']);
+
+                if ($packageQueue && $packageQueue->is_released) {
+                    // Store the released packages before clearing them
+                    $releasedPackages = $packageQueue->released_packages ?? [];
+
+                    // Create a release log entry for the return
+                    PackageReleaseLog::create([
+                        'package_queue_id' => $packageQueue->id,
+                        'type' => 'return',
+                        'packages' => [
+                            [
+                                'reference' => $packageQueue->reference,
+                                'package_count' => $packageQueue->package_count,
+                                'returned_at' => now()->toDateTimeString(),
+                                'original_released_packages' => $releasedPackages,
+                            ],
+                        ],
+                        'remarks' => $data['remarks'] ?? null,
+                        'created_by' => auth()->id(),
+                    ]);
+
+                    // Update the package queue to mark as not released
+                    $packageQueue->update([
+                        'is_released' => false,
+                        'released_at' => null,
+                        'released_packages' => null,
+                        'note' => $data['remarks'] ?? null,
+                        'auth_id' => auth()->id(),
+                    ]);
+                }
+            }
+
+            return;
+        }
+
+        // Legacy single package return (maintain backward compatibility)
         $packageQueue = PackageQueue::whereHas('token', function ($query) use ($data) {
             $query->where('token', $data['token_number']);
         })->first();

--- a/app/Repositories/CallCenter/QueueRepository.php
+++ b/app/Repositories/CallCenter/QueueRepository.php
@@ -188,7 +188,7 @@ class QueueRepository implements QueueRepositoryInterface
     public function returnPackage(array $data): void
     {
         // Handle selective package returns
-        if (isset($data['selected_packages']) && ! empty($data['selected_packages'])) {
+        if (isset($data['selected_packages'])) {
             foreach ($data['selected_packages'] as $packageData) {
                 $packageQueue = PackageQueue::find($packageData['package_queue_id']);
 

--- a/resources/js/Pages/CallCenter/BonedArea/QueueList.vue
+++ b/resources/js/Pages/CallCenter/BonedArea/QueueList.vue
@@ -80,7 +80,7 @@ const loadPackageDetails = async () => {
         if (error.response?.status === 404) {
             push.error('No packages found for this token!');
         } else {
-            push.error('Error loading package details');
+            push.error(`Error loading package details: ${error.message || error.response?.status || 'Unknown error'}`);
         }
         returnForm.package_details = null;
     }

--- a/resources/js/Pages/CallCenter/BonedArea/QueueList.vue
+++ b/resources/js/Pages/CallCenter/BonedArea/QueueList.vue
@@ -15,6 +15,12 @@ import PackageReleaseDialog from "@/Pages/CallCenter/BonedArea/PackageReleaseDia
 import Dialog from "primevue/dialog";
 import InputText from 'primevue/inputtext';
 import Textarea from 'primevue/textarea';
+import Accordion from 'primevue/accordion';
+import AccordionTab from 'primevue/accordiontab';
+import Checkbox from 'primevue/checkbox';
+import Dropdown from 'primevue/dropdown';
+import Divider from 'primevue/divider';
+import Panel from 'primevue/panel';
 import {push} from "notivue";
 import axios from 'axios';
 import {useForm} from "@inertiajs/vue3";
@@ -52,7 +58,8 @@ const returnDialogVisible = ref(false);
 const returnForm = useForm({
     token_number: '',
     package_details: null,
-    remarks: ''
+    remarks: '',
+    selected_packages: []
 });
 
 const showReturnDialog = () => {
@@ -60,23 +67,94 @@ const showReturnDialog = () => {
 };
 
 const loadPackageDetails = async () => {
-    if (!returnForm.token_number) return;
+    if (!returnForm.token_number) {
+        returnForm.package_details = null;
+        return;
+    }
 
     try {
-        const response = await axios.get(`/call-center/get-package-details-by-token/${returnForm.token_number}`);
+        const response = await axios.get(`/call-center/get-packages-for-return/${returnForm.token_number}`);
         returnForm.package_details = response.data;
+        returnForm.selected_packages = []; // Reset selections
     } catch (error) {
-        if (error.response.status === 404) {
-            push.error('Package not found!');
+        if (error.response?.status === 404) {
+            push.error('No packages found for this token!');
+        } else {
+            push.error('Error loading package details');
         }
         returnForm.package_details = null;
     }
 };
 
+const togglePackageSelection = (packageData) => {
+    const index = returnForm.selected_packages.findIndex(
+        p => p.package_queue_id === packageData.package_queue_id
+    );
+    
+    if (index >= 0) {
+        // Remove from selection
+        returnForm.selected_packages.splice(index, 1);
+    } else {
+        // Add to selection (only if released)
+        if (packageData.is_released) {
+            returnForm.selected_packages.push({
+                package_queue_id: packageData.package_queue_id,
+                reference: packageData.reference,
+                package_count: packageData.package_count
+            });
+        }
+    }
+};
+
+const isPackageSelected = (packageData) => {
+    return returnForm.selected_packages.some(
+        p => p.package_queue_id === packageData.package_queue_id
+    );
+};
+
+const selectAllPackagesInHBL = (hblGroup) => {
+    const releasedPackages = hblGroup.packages.filter(pkg => pkg.is_released);
+    
+    // Check if all released packages in this HBL are already selected
+    const allSelected = releasedPackages.every(pkg => isPackageSelected(pkg));
+    
+    if (allSelected) {
+        // Deselect all packages in this HBL
+        releasedPackages.forEach(pkg => {
+            const index = returnForm.selected_packages.findIndex(
+                p => p.package_queue_id === pkg.package_queue_id
+            );
+            if (index >= 0) {
+                returnForm.selected_packages.splice(index, 1);
+            }
+        });
+    } else {
+        // Select all released packages in this HBL
+        releasedPackages.forEach(pkg => {
+            if (!isPackageSelected(pkg)) {
+                returnForm.selected_packages.push({
+                    package_queue_id: pkg.package_queue_id,
+                    reference: pkg.reference,
+                    package_count: pkg.package_count
+                });
+            }
+        });
+    }
+};
+
+const removeSelectedPackage = (index) => {
+    returnForm.selected_packages.splice(index, 1);
+};
+
 const handleReturnPackage = () => {
+    if (returnForm.selected_packages.length === 0) {
+        push.error('Please select at least one package to return!');
+        return;
+    }
+
     returnForm.post(route('call-center.package.return'), {
         onSuccess: () => {
-            push.success('Package returned successfully!');
+            push.success(`${returnForm.selected_packages.length} package(s) returned successfully!`);
             returnDialogVisible.value = false;
             returnForm.reset();
             // Refresh the package queue data
@@ -232,66 +310,214 @@ const showLogDialog = (token) => {
                           @close="closePackageReleaseModal"
                           @update:visible="showPackageReleaseDialog = $event"/>
 
-    <Dialog :style="{ width: '40rem' }" :visible="returnDialogVisible" header="Return Package" modal @update:visible="returnDialogVisible = $event">
-        <div class="space-y-4">
+    <Dialog :style="{ width: '70rem' }" :visible="returnDialogVisible" header="Return Package - Enhanced Selection" modal @update:visible="returnDialogVisible = $event">
+        <div class="space-y-6">
+            <!-- Token Number Input -->
             <div class="field">
-                <label for="token_number" class="block mb-2">Token Number</label>
-                <InputText
-                    id="token_number"
-                    v-model="returnForm.token_number"
-                    class="w-full"
-                    @blur="loadPackageDetails"
-                    @keyup.enter="loadPackageDetails"
-                />
+                <label for="token_number" class="block mb-2 font-semibold">Token Number</label>
+                <div class="flex gap-2">
+                    <InputText
+                        id="token_number"
+                        v-model="returnForm.token_number"
+                        class="flex-1"
+                        placeholder="Enter token number (e.g., 1, 2, 3...)"
+                        @keyup.enter="loadPackageDetails"
+                    />
+                    <Button 
+                        label="Load Packages" 
+                        icon="pi pi-search" 
+                        @click="loadPackageDetails"
+                        :disabled="!returnForm.token_number"
+                    />
+                </div>
                 <div v-if="returnForm.errors.token_number" class="text-red-500 text-sm mt-1">
                     {{ returnForm.errors.token_number }}
                 </div>
             </div>
 
-            <div v-if="returnForm.package_details" class="border rounded p-4">
-                <h3 class="font-bold mb-2">Package Details</h3>
-                <div class="grid grid-cols-2 gap-2">
-                    <div><strong>Reference:</strong> {{ returnForm.package_details.reference }}</div>
-                    <div><strong>Customer:</strong> {{ returnForm.package_details.customer }}</div>
-                    <div><strong>Package Count:</strong> {{ returnForm.package_details.package_count }}</div>
-                    <div><strong>Released At:</strong> {{ returnForm.package_details.released_at }}</div>
+            <!-- Package Details Section -->
+            <div v-if="returnForm.package_details" class="space-y-4">
+                <!-- Summary -->
+                <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
+                    <h3 class="font-bold text-lg mb-2 text-blue-800">📦 Token Summary</h3>
+                    <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+                        <div>
+                            <strong>Token:</strong> {{ returnForm.package_details.token_number }}
+                        </div>
+                        <div>
+                            <strong>Customer:</strong> {{ returnForm.package_details.customer }}
+                        </div>
+                        <div>
+                            <strong>Total HBLs:</strong> {{ returnForm.package_details.summary.total_hbls }}
+                        </div>
+                        <div>
+                            <strong>Available for Return:</strong> 
+                            <Tag :value="returnForm.package_details.summary.available_for_return" severity="info" />
+                        </div>
+                    </div>
                 </div>
 
-                <div class="mt-3" v-if="returnForm.package_details.released_packages">
-                    <h4 class="font-bold mb-1">Released Packages:</h4>
-                    <ul class="list-disc pl-5">
-                        <li v-for="(pkg, key) in returnForm.package_details.released_packages" :key="key">
-                            {{ key }}
-                        </li>
-                    </ul>
+                <!-- HBL Groups -->
+                <div class="space-y-3">
+                    <h4 class="font-bold text-base flex items-center gap-2">
+                        <i class="pi pi-list"></i>
+                        Select Packages to Return
+                    </h4>
+                    
+                    <Accordion multiple>
+                        <AccordionTab 
+                            v-for="(hblGroup, index) in returnForm.package_details.hbl_groups" 
+                            :key="index"
+                            :header="`📋 HBL: ${hblGroup.hbl_reference} (${hblGroup.released_packages}/${hblGroup.total_packages} released)`"
+                        >
+                            <div class="space-y-3">
+                                <!-- HBL Actions -->
+                                <div class="flex justify-between items-center bg-gray-50 p-3 rounded">
+                                    <div class="text-sm text-gray-600">
+                                        <strong>Customer:</strong> {{ hblGroup.customer }}
+                                    </div>
+                                    <Button 
+                                        :label="hblGroup.packages.filter(pkg => pkg.is_released).every(pkg => isPackageSelected(pkg)) ? 'Deselect All' : 'Select All Released'"
+                                        :severity="hblGroup.packages.filter(pkg => pkg.is_released).every(pkg => isPackageSelected(pkg)) ? 'secondary' : 'info'"
+                                        size="small"
+                                        @click="selectAllPackagesInHBL(hblGroup)"
+                                        :disabled="hblGroup.packages.filter(pkg => pkg.is_released).length === 0"
+                                    />
+                                </div>
+
+                                <!-- Package List -->
+                                <div class="grid gap-3">
+                                    <div 
+                                        v-for="packageData in hblGroup.packages" 
+                                        :key="packageData.id"
+                                        class="border rounded-lg p-4 transition-all"
+                                        :class="{
+                                            'border-green-300 bg-green-50': packageData.is_released && isPackageSelected(packageData),
+                                            'border-blue-300 bg-blue-50': packageData.is_released && !isPackageSelected(packageData),
+                                            'border-gray-300 bg-gray-50': !packageData.is_released
+                                        }"
+                                    >
+                                        <div class="flex items-start justify-between">
+                                            <div class="flex items-start gap-3 flex-1">
+                                                <!-- Selection Checkbox -->
+                                                <Checkbox 
+                                                    v-if="packageData.is_released"
+                                                    :modelValue="isPackageSelected(packageData)"
+                                                    @update:modelValue="togglePackageSelection(packageData)"
+                                                    :binary="true"
+                                                />
+                                                <div v-else class="w-6"></div>
+
+                                                <!-- Package Info -->
+                                                <div class="flex-1">
+                                                    <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-sm mb-2">
+                                                        <div><strong>Reference:</strong> {{ packageData.reference }}</div>
+                                                        <div><strong>Packages:</strong> {{ packageData.package_count }}</div>
+                                                        <div><strong>Status:</strong> 
+                                                            <Tag 
+                                                                :value="packageData.is_released ? 'Released' : 'Not Released'"
+                                                                :severity="packageData.is_released ? 'success' : 'warning'"
+                                                            />
+                                                        </div>
+                                                        <div v-if="packageData.released_at">
+                                                            <strong>Released:</strong> {{ new Date(packageData.released_at).toLocaleDateString() }}
+                                                        </div>
+                                                    </div>
+                                                    
+                                                    <!-- Release History -->
+                                                    <div v-if="packageData.logs && packageData.logs.length > 0" class="mt-2">
+                                                        <details class="text-xs">
+                                                            <summary class="cursor-pointer text-blue-600 hover:text-blue-800">View History ({{ packageData.logs.length }} entries)</summary>
+                                                            <div class="mt-2 space-y-1 pl-4 border-l-2 border-gray-200">
+                                                                <div v-for="log in packageData.logs" :key="log.id" class="bg-gray-100 p-2 rounded">
+                                                                    <div class="flex justify-between items-center">
+                                                                        <Tag :value="log.type" :severity="log.type === 'return' ? 'warning' : 'success'" />
+                                                                        <span class="text-xs text-gray-500">{{ new Date(log.created_at).toLocaleString() }}</span>
+                                                                    </div>
+                                                                    <div v-if="log.remarks" class="text-xs mt-1">{{ log.remarks }}</div>
+                                                                    <div v-if="log.created_by" class="text-xs text-gray-600">by {{ log.created_by }}</div>
+                                                                </div>
+                                                            </div>
+                                                        </details>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </AccordionTab>
+                    </Accordion>
+                </div>
+
+                <!-- Selected Packages Summary -->
+                <div v-if="returnForm.selected_packages.length > 0" class="bg-green-50 border border-green-200 rounded-lg p-4">
+                    <h4 class="font-bold text-green-800 mb-2 flex items-center gap-2">
+                        <i class="pi pi-check-circle"></i>
+                        Selected Packages for Return ({{ returnForm.selected_packages.length }})
+                    </h4>
+                    <div class="flex flex-wrap gap-2">
+                        <div 
+                            v-for="(pkg, index) in returnForm.selected_packages" 
+                            :key="index"
+                            class="flex items-center gap-2 bg-white border border-green-300 rounded-full px-3 py-1 text-sm"
+                        >
+                            <span>{{ pkg.reference }} ({{ pkg.package_count }})</span>
+                            <Button 
+                                icon="pi pi-times" 
+                                severity="danger" 
+                                text 
+                                rounded 
+                                size="small"
+                                @click="removeSelectedPackage(index)"
+                            />
+                        </div>
+                    </div>
                 </div>
             </div>
 
+            <!-- Remarks -->
             <div class="field">
-                <label for="return_remarks" class="block mb-2">Remarks</label>
+                <label for="return_remarks" class="block mb-2 font-semibold">Return Remarks</label>
                 <Textarea
                     id="return_remarks"
                     v-model="returnForm.remarks"
                     class="w-full"
                     rows="3"
-                    placeholder="Enter return remarks..."
+                    placeholder="Enter reason for return..."
                 />
                 <div v-if="returnForm.errors.remarks" class="text-red-500 text-sm mt-1">
                     {{ returnForm.errors.remarks }}
                 </div>
+                <div v-if="returnForm.errors.selected_packages" class="text-red-500 text-sm mt-1">
+                    {{ returnForm.errors.selected_packages }}
+                </div>
             </div>
         </div>
 
-        <div class="flex justify-end gap-2 mt-4">
-            <Button label="Cancel" severity="secondary" type="button" @click="returnDialogVisible = false"></Button>
-            <Button
-                :disabled="!returnForm.package_details || returnForm.processing"
-                :class="{ 'opacity-75': returnForm.processing }"
-                label="Process Return"
-                type="button"
-                @click="handleReturnPackage"
-            ></Button>
-        </div>
+        <template #footer>
+            <div class="flex justify-between items-center">
+                <div class="text-sm text-gray-600">
+                    <span v-if="returnForm.selected_packages.length > 0">
+                        {{ returnForm.selected_packages.length }} package(s) selected for return
+                    </span>
+                </div>
+                <div class="flex gap-2">
+                    <Button 
+                        label="Cancel" 
+                        severity="secondary" 
+                        @click="returnDialogVisible = false"
+                    />
+                    <Button
+                        :disabled="returnForm.selected_packages.length === 0 || returnForm.processing"
+                        :class="{ 'opacity-75': returnForm.processing }"
+                        label="Process Return"
+                        icon="pi pi-check"
+                        @click="handleReturnPackage"
+                    />
+                </div>
+            </div>
+        </template>
     </Dialog>
 
     <!-- Add Log Dialog -->

--- a/routes/web/call-center/queue.php
+++ b/routes/web/call-center/queue.php
@@ -25,6 +25,9 @@ Route::get('/get-package-queue', [QueueController::class, 'getPackageQueue']);
 Route::get('/get-package-details-by-token/{token}', [QueueController::class, 'getPackageDetailsByToken'])
     ->name('package.details.by.token');
 
+Route::get('/get-packages-for-return/{token}', [QueueController::class, 'getPackagesForReturn'])
+    ->name('packages.for.return');
+
 Route::post('/return-package', [QueueController::class, 'returnPackage'])
     ->name('package.return');
 


### PR DESCRIPTION
- Add API endpoint to fetch packages grouped by HBL for a given token
- Implement selective package return handling with validation in ReturnPackageRequest
- Update QueueRepository to support partial returns with release logs and status update
- Enhance return package UI with token summary, accordion HBL groups, and package selection checkboxes
- Add “Select All” and individual package toggling with visual indicators for release status
- Support loading packages by token number with error handling and reset logic
- Improve return form validation to require token number or selected packages
- Add detailed release history display per package in return dialog
- Modify front-end to submit selected packages array for returns instead of single token-based return
- Update route definitions to include new package fetching endpoint for returns